### PR TITLE
Update GlobalConfig default value and remove default_src function

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -9,12 +9,7 @@ use std::path::{Path, PathBuf};
 
 #[derive(Deserialize, Debug, Default)]
 pub struct GlobalConfig {
-    #[serde(default = "default_src")]
     pub src: PathBuf,
-}
-
-fn default_src() -> PathBuf {
-    PathBuf::from("src")
 }
 
 impl GlobalConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,7 +25,9 @@ impl GlobalConfig {
             file.read_to_string(&mut buf).unwrap_or_default();
             toml::from_str::<GlobalConfig>(&buf).unwrap_or_default()
         } else {
-            GlobalConfig::default()
+            Self {
+                src: PathBuf::from("src"),
+            }
         }
     }
 


### PR DESCRIPTION
This pull request updates the default value of the `src` field in the `GlobalConfig` struct and removes the `default_src` function. The `src` field now defaults to "src" if no value is provided. This change improves the readability and simplifies the code.