### PR TITLE
Use String::default instead of String::new

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -16,7 +16,7 @@ impl GlobalConfig {
     pub fn new() -> Self {
         let path = Self::get_path();
         if let Ok(mut file) = fs::File::open(path) {
-            let mut buf = String::new();
+            let mut buf = String::default();
             file.read_to_string(&mut buf).unwrap_or_default();
             toml::from_str::<GlobalConfig>(&buf).unwrap_or_default()
         } else {
@@ -57,7 +57,7 @@ pub struct Command {
 impl Config {
     pub fn from_path(confpath: &Path) -> Result<Self> {
         let mut file = fs::File::open(confpath)?;
-        let mut buf = String::new();
+        let mut buf = String::default();
         file.read_to_string(&mut buf)?;
         Ok(toml::from_str::<Config>(&buf)?)
     }

--- a/src/show.rs
+++ b/src/show.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use tracing::info;
 
 fn read_text(f: &mut fs::File) -> Result<Content> {
-    let mut buf = String::new();
+    let mut buf = String::default();
     f.read_to_string(&mut buf)?;
     let ss = buf.lines().map(String::from).collect();
     Ok(Content::Text(ss))
@@ -52,7 +52,7 @@ fn check_binary_diff(ssz: usize, sb: Vec<u8>, tsz: usize, tb: Vec<u8>) -> String
             tsz
         )
     } else {
-        String::new()
+        String::default()
     }
 }
 


### PR DESCRIPTION
This pull request updates the code to use `String::default` instead of `String::new` in multiple places.