### PR TITLE
Bump edition to 2024 and use unsafe block for environment variable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["yasuyuky <yasuyuki.ymd@gmail.com>"]
 description = "A command line utility to manage configuration files in one place"
-edition = "2021"
+edition = "2024"
 exclude = [".*"]
 license = "MIT"
 name = "wagon"

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,7 +101,7 @@ fn main() -> Result<()> {
     let opt = Opt::parse();
     let command = opt.cmd;
     if opt.color {
-        std::env::set_var("CLICOLOR_FORCE", "1");
+        unsafe { std::env::set_var("CLICOLOR_FORCE", "1") }
     }
     let current_dir = std::env::current_dir().expect("current dir");
     let base = opt.base.unwrap_or(current_dir);

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ use structs::{Content, Link};
 
 const CONFFILE_NAME: &str = ".wagon.toml";
 const IGNOREFILE_NAME: &str = ".wagonignore";
-
+const CLICOLOR_FORCE: &str = "CLICOLOR_FORCE";
 #[derive(Parser)]
 struct Opt {
     #[clap(long)]
@@ -101,7 +101,7 @@ fn main() -> Result<()> {
     let opt = Opt::parse();
     let command = opt.cmd;
     if opt.color {
-        unsafe { std::env::set_var("CLICOLOR_FORCE", "1") }
+        unsafe { std::env::set_var(CLICOLOR_FORCE, "1") }
     }
     let current_dir = std::env::current_dir().expect("current dir");
     let base = opt.base.unwrap_or(current_dir);


### PR DESCRIPTION
Update the Rust edition in Cargo.toml to 2024 and modify the setting of the CLICOLOR_FORCE environment variable to use an unsafe block for improved safety.