### PR TITLE
Use the current directory as the wagon pull destination

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -129,7 +129,7 @@ enum Command {
     /// current directory, preserving structure.
     Pull {
         /// One or more absolute paths in the destination to pull from.
-        #[clap(required = true, value_parser = absolute_path)]
+        #[clap(required = true, value_parser = pull::absolute_path)]
         target: Vec<PathBuf>,
     },
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,11 +114,10 @@ enum Command {
         dir: Vec<PathBuf>,
     },
 
-    /// Pull existing files from destination back into the repo, then relink.
+    /// Pull existing files from destination back into the repo.
     ///
     /// Copies files from the destination (from config.dest or $HOME) into the
-    /// specified repo subdirectory, preserving structure, and then runs `link`
-    /// on that directory to create symlinks back to the pulled files.
+    /// specified repo subdirectory, preserving structure.
     Pull {
         /// Repo subdirectory (relative to --base) to copy files into.
         dir: PathBuf,

--- a/src/main.rs
+++ b/src/main.rs
@@ -202,7 +202,7 @@ fn main() -> Result<()> {
         unsafe { std::env::set_var(CLICOLOR_FORCE, "1") }
     }
     let current_dir = std::env::current_dir().expect("current dir");
-    let base = opt.base.unwrap_or(current_dir);
+    let base = opt.base.unwrap_or_else(|| current_dir.clone());
     let cwd_or = |dirs: Vec<PathBuf>| -> Vec<PathBuf> {
         if dirs.is_empty() {
             vec![std::env::current_dir().expect("current dir")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,15 @@ struct Opt {
     cmd: Command,
 }
 
+fn absolute_path(value: &str) -> std::result::Result<PathBuf, String> {
+    let path = PathBuf::from(value);
+    if path.is_absolute() {
+        Ok(path)
+    } else {
+        Err("target must be an absolute path".to_owned())
+    }
+}
+
 #[derive(Debug, Parser)]
 #[clap(rename_all = "kebab-case")]
 enum Command {

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,11 +126,10 @@ enum Command {
     /// Pull existing files from destination back into the repo.
     ///
     /// Copies files from the destination (from config.dest or $HOME) into the
-    /// specified repo subdirectory, preserving structure.
+    /// current directory, preserving structure.
     Pull {
-        /// Repo subdirectory (relative to --base) to copy files into.
-        dir: PathBuf,
         /// One or more absolute paths in the destination to pull from.
+        #[clap(required = true, value_parser = absolute_path)]
         target: Vec<PathBuf>,
     },
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,15 +46,6 @@ struct Opt {
     cmd: Command,
 }
 
-fn absolute_path(value: &str) -> std::result::Result<PathBuf, String> {
-    let path = PathBuf::from(value);
-    if path.is_absolute() {
-        Ok(path)
-    } else {
-        Err("target must be an absolute path".to_owned())
-    }
-}
-
 #[derive(Debug, Parser)]
 #[clap(rename_all = "kebab-case")]
 enum Command {

--- a/src/main.rs
+++ b/src/main.rs
@@ -217,7 +217,7 @@ fn main() -> Result<()> {
         Command::List { dir } => show::show_list(&base, &cwd_or(dir))?,
         Command::Init { dir } => init::run_inits(&base, &cwd_or(dir))?,
         Command::Update { dir } => update::run_updates(&base, &cwd_or(dir))?,
-        Command::Pull { dir, target } => pull::pull_files(&base, &dir, &cwd_or(target))?,
+        Command::Pull { target } => pull::pull_files(&base, &current_dir, &target)?,
         Command::Repo { pathlikes } => {
             for pathlike in pathlikes {
                 if pathlike == "checkout" {

--- a/src/pull.rs
+++ b/src/pull.rs
@@ -48,11 +48,12 @@ mod tests {
 
     #[test]
     fn pull_accepts_targets_without_dir() {
-        let opt = Opt::try_parse_from(["wagon", "pull", "/tmp/.zshrc"]).unwrap();
+        let target_path = "/example/.zshrc";
+        let opt = Opt::try_parse_from(["wagon", "pull", target_path]).unwrap();
         let Command::Pull { target } = opt.cmd else {
             panic!("expected pull command");
         };
-        assert_eq!(target, vec![PathBuf::from("/tmp/.zshrc")]);
+        assert_eq!(target, vec![PathBuf::from(target_path)]);
     }
 
     #[test]

--- a/src/pull.rs
+++ b/src/pull.rs
@@ -39,3 +39,27 @@ pub fn pull_files(base: &Path, dir: &Path, targets: &[PathBuf]) -> Result<()> {
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Command, Opt};
+    use clap::Parser;
+
+    #[test]
+    fn pull_accepts_targets_without_dir() {
+        let opt = Opt::try_parse_from(["wagon", "pull", "/tmp/.zshrc"]).unwrap();
+        let Command::Pull { target } = opt.cmd else {
+            panic!("expected pull command");
+        };
+        assert_eq!(target, vec![PathBuf::from("/tmp/.zshrc")]);
+    }
+
+    #[test]
+    fn pull_rejects_relative_targets() {
+        let Err(err) = Opt::try_parse_from(["wagon", "pull", "zsh"]) else {
+            panic!("expected parse error");
+        };
+        assert!(err.to_string().contains("target must be an absolute path"));
+    }
+}

--- a/src/pull.rs
+++ b/src/pull.rs
@@ -5,6 +5,15 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use tracing::info;
 
+pub fn absolute_path(value: &str) -> std::result::Result<PathBuf, String> {
+    let path = PathBuf::from(value);
+    if path.is_absolute() {
+        Ok(path)
+    } else {
+        Err("target must be an absolute path".to_owned())
+    }
+}
+
 pub fn pull_files(base: &Path, dir: &Path, targets: &[PathBuf]) -> Result<()> {
     if let Some(conf) = get_config(&base.join(dir))? {
         let dest = conf.dest.unwrap_or_else(|| dirs::home_dir().unwrap());


### PR DESCRIPTION
## Summary
- Remove the destination `dir` argument from `wagon pull` and use the current directory as the pull destination.
- Require `pull` targets to be absolute paths to avoid ambiguous legacy argument parsing.
- Add pull-specific input validation tests in `src/pull.rs`.

## Testing
- `RUST_TEST_THREADS=1 cargo test`
- `cargo clippy --all-targets -- -D warnings`