### PR TITLE
Preserve ANSI escape sequences in log output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -169,6 +169,7 @@ fn init_tracing() {
         .with_max_level(tracing::Level::INFO)
         .with_level(false)
         .with_target(false)
+        .with_ansi_sanitization(false)
         .finish();
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -169,7 +169,6 @@ fn init_tracing() {
         .with_max_level(tracing::Level::INFO)
         .with_level(false)
         .with_target(false)
-        .with_ansi_sanitization(false)
         .finish();
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
 }

--- a/src/show.rs
+++ b/src/show.rs
@@ -99,6 +99,8 @@ pub fn show_list(dirs: &[PathBuf]) -> Result<()> {
     for dir in dirs {
         if fs::metadata(dir)?.is_dir() {
             if let Some(name) = dir.file_name() {
+                // Keep ls as direct CLI output so fixed labels can use ANSI
+                // without disabling tracing sanitization globally.
                 eprintln!("{}", sanitize_display(&name.to_string_lossy()).bold());
             }
             eprintln!("{}", show_link(dir)?)

--- a/src/show.rs
+++ b/src/show.rs
@@ -1,35 +1,13 @@
-use crate::{Content, Link, list::list_items};
+use crate::{
+    Content, Link,
+    list::list_items,
+    structs::{display_path, sanitize_display},
+};
 use anyhow::Result;
 use colored::Colorize;
 use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
-
-fn sanitize(text: &str) -> String {
-    let mut out = String::with_capacity(text.len());
-    for ch in text.chars() {
-        match ch {
-            '\x1b' => out.push_str("\\x1b"),
-            '\x07' => out.push_str("\\x07"),
-            '\x08' => out.push_str("\\x08"),
-            '\x0c' => out.push_str("\\x0c"),
-            '\x7f' => out.push_str("\\x7f"),
-            ch if ('\u{80}'..='\u{9f}').contains(&ch) => {
-                out.push_str(&format!("\\u{{{:x}}}", ch as u32));
-            }
-            _ => out.push(ch),
-        }
-    }
-    out
-}
-
-fn safe_path(path: &Path) -> String {
-    sanitize(&path.to_string_lossy())
-}
-
-fn safe_link(link: &Link) -> String {
-    format!("{} -> {}", safe_path(&link.target), safe_path(&link.source))
-}
 
 fn read_text(f: &mut fs::File) -> Result<Content> {
     let mut buf = String::default();
@@ -56,7 +34,7 @@ fn get_text_diff(ss: &[String], ts: &[String], sp: &str, tp: &str, sd: &str, td:
     difflib::unified_diff(ss, ts, sp, tp, sd, td, 3)
         .iter()
         .map(|line| {
-            let line = sanitize(line.trim_end());
+            let line = sanitize_display(line.trim_end());
             if line.starts_with('+') {
                 format!("{}", line.green())
             } else if line.starts_with('-') {
@@ -98,20 +76,20 @@ fn show_link(base: &Path) -> Result<String> {
         if link.target.exists() {
             if let Ok(readlink) = fs::read_link(&link.target) {
                 if readlink == link.source {
-                    vs.push(format!("{}: {}", "LINKING".cyan(), safe_link(&link)))
+                    vs.push(format!("{}: {}", "LINKING".cyan(), &link))
                 }
             } else {
                 vs.push(format!(
                     "{}: {}",
                     "EXISTS".magenta(),
-                    safe_path(&link.target)
+                    display_path(&link.target)
                 ));
                 if !link.is_dir {
                     vs.push(show_content_diff(&link)?)
                 }
             }
         } else {
-            vs.push(format!("{}: {}", "NOLINK".yellow(), safe_link(&link)))
+            vs.push(format!("{}: {}", "NOLINK".yellow(), &link))
         }
     }
     Ok(vs.join("\n"))
@@ -121,7 +99,7 @@ pub fn show_list(dirs: &[PathBuf]) -> Result<()> {
     for dir in dirs {
         if fs::metadata(dir)?.is_dir() {
             if let Some(name) = dir.file_name() {
-                eprintln!("{}", sanitize(&name.to_string_lossy()).bold());
+                eprintln!("{}", sanitize_display(&name.to_string_lossy()).bold());
             }
             eprintln!("{}", show_link(dir)?)
         }

--- a/src/show.rs
+++ b/src/show.rs
@@ -4,7 +4,32 @@ use colored::Colorize;
 use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
-use tracing::info;
+
+fn sanitize(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    for ch in text.chars() {
+        match ch {
+            '\x1b' => out.push_str("\\x1b"),
+            '\x07' => out.push_str("\\x07"),
+            '\x08' => out.push_str("\\x08"),
+            '\x0c' => out.push_str("\\x0c"),
+            '\x7f' => out.push_str("\\x7f"),
+            ch if ('\u{80}'..='\u{9f}').contains(&ch) => {
+                out.push_str(&format!("\\u{{{:x}}}", ch as u32));
+            }
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
+fn safe_path(path: &Path) -> String {
+    sanitize(&path.to_string_lossy())
+}
+
+fn safe_link(link: &Link) -> String {
+    format!("{} -> {}", safe_path(&link.target), safe_path(&link.source))
+}
 
 fn read_text(f: &mut fs::File) -> Result<Content> {
     let mut buf = String::default();
@@ -31,12 +56,13 @@ fn get_text_diff(ss: &[String], ts: &[String], sp: &str, tp: &str, sd: &str, td:
     difflib::unified_diff(ss, ts, sp, tp, sd, td, 3)
         .iter()
         .map(|line| {
+            let line = sanitize(line.trim_end());
             if line.starts_with('+') {
-                format!("{}", line.trim_end().green())
+                format!("{}", line.green())
             } else if line.starts_with('-') {
-                format!("{}", line.trim_end().red())
+                format!("{}", line.red())
             } else {
-                line.trim_end().to_string()
+                line
             }
         })
         .collect::<Vec<String>>()
@@ -72,17 +98,20 @@ fn show_link(base: &Path) -> Result<String> {
         if link.target.exists() {
             if let Ok(readlink) = fs::read_link(&link.target) {
                 if readlink == link.source {
-                    vs.push(format!("{}: {}", "LINKING".cyan(), &link))
+                    vs.push(format!("{}: {}", "LINKING".cyan(), safe_link(&link)))
                 }
             } else {
-                let tgt = link.target.to_str().unwrap_or_default();
-                vs.push(format!("{}: {}", "EXISTS".magenta(), tgt));
+                vs.push(format!(
+                    "{}: {}",
+                    "EXISTS".magenta(),
+                    safe_path(&link.target)
+                ));
                 if !link.is_dir {
                     vs.push(show_content_diff(&link)?)
                 }
             }
         } else {
-            vs.push(format!("{}: {}", "NOLINK".yellow(), &link))
+            vs.push(format!("{}: {}", "NOLINK".yellow(), safe_link(&link)))
         }
     }
     Ok(vs.join("\n"))
@@ -92,9 +121,9 @@ pub fn show_list(dirs: &[PathBuf]) -> Result<()> {
     for dir in dirs {
         if fs::metadata(dir)?.is_dir() {
             if let Some(name) = dir.file_name() {
-                info!("{}", name.to_string_lossy().bold());
+                eprintln!("{}", sanitize(&name.to_string_lossy()).bold());
             }
-            info!("{}", show_link(dir)?)
+            eprintln!("{}", show_link(dir)?)
         }
     }
     Ok(())

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -1,4 +1,30 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+pub(crate) fn sanitize_display(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    for ch in text.chars() {
+        match ch {
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            '\x1b' => out.push_str("\\x1b"),
+            '\x07' => out.push_str("\\x07"),
+            '\x08' => out.push_str("\\x08"),
+            '\x0c' => out.push_str("\\x0c"),
+            '\x7f' => out.push_str("\\x7f"),
+            ch if ch < ' ' => out.push_str(&format!("\\x{:02x}", ch as u32)),
+            ch if ('\u{80}'..='\u{9f}').contains(&ch) => {
+                out.push_str(&format!("\\u{{{:x}}}", ch as u32));
+            }
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
+pub(crate) fn display_path(path: &Path) -> String {
+    sanitize_display(&path.to_string_lossy())
+}
 
 #[derive(Debug, Clone)]
 pub struct Link {
@@ -22,8 +48,8 @@ impl std::fmt::Display for Link {
         write!(
             f,
             "{} -> {}",
-            self.target.to_str().unwrap_or_default(),
-            self.source.to_str().unwrap_or_default()
+            display_path(&self.target),
+            display_path(&self.source)
         )
     }
 }
@@ -31,4 +57,20 @@ impl std::fmt::Display for Link {
 pub enum Content {
     Text(Vec<String>),
     Binary(usize, Vec<u8>),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn link_display_sanitizes_control_chars() {
+        let link = Link::new(
+            PathBuf::from("src\x1b]2;owned\x07"),
+            PathBuf::from("dst\nbad"),
+            false,
+        );
+
+        assert_eq!(format!("{link}"), "dst\\nbad -> src\\x1b]2;owned\\x07");
+    }
 }

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -66,11 +66,14 @@ mod tests {
     #[test]
     fn link_display_sanitizes_control_chars() {
         let link = Link::new(
-            PathBuf::from("src\x1b]2;owned\x07"),
-            PathBuf::from("dst\nbad"),
+            PathBuf::from("src\x1b]2;owned\x07\tname"),
+            PathBuf::from("dst\nbad\rname"),
             false,
         );
 
-        assert_eq!(format!("{link}"), "dst\\nbad -> src\\x1b]2;owned\\x07");
+        assert_eq!(
+            format!("{link}"),
+            "dst\\nbad\\rname -> src\\x1b]2;owned\\x07\\tname"
+        );
     }
 }

--- a/tests/color.rs
+++ b/tests/color.rs
@@ -1,3 +1,4 @@
+use std::fs;
 use std::process::Command;
 
 fn contains(bytes: &[u8], needle: &[u8]) -> bool {
@@ -15,4 +16,26 @@ fn color_output_keeps_escape_sequences() {
     let output = [output.stdout, output.stderr].concat();
     assert!(contains(&output, b"\x1b[1mba"));
     assert!(!contains(&output, br"\x1b"));
+}
+
+#[test]
+fn color_output_sanitizes_repo_paths() {
+    let base = std::env::temp_dir().join(format!("wagon-color-test-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&base);
+    fs::create_dir_all(&base).expect("create temp repo");
+    fs::write(base.join("bad\x1b]2;owned\x07"), "").expect("write temp file");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_wagon"))
+        .args(["--color", "--base"])
+        .arg(&base)
+        .arg("ls")
+        .output()
+        .expect("run wagon");
+    let _ = fs::remove_dir_all(&base);
+
+    assert!(output.status.success(), "command failed: {output:?}");
+    let output = [output.stdout, output.stderr].concat();
+    assert!(contains(&output, b"\x1b["));
+    assert!(contains(&output, br"bad\x1b]2;owned\x07"));
+    assert!(!contains(&output, b"\x1b]2;owned"));
 }

--- a/tests/color.rs
+++ b/tests/color.rs
@@ -26,7 +26,7 @@ fn color_output_sanitizes_repo_paths() {
     let base = std::env::temp_dir().join(format!("wagon-color-test-{}", std::process::id()));
     let _ = fs::remove_dir_all(&base);
     fs::create_dir_all(&base).expect("create temp repo");
-    fs::write(base.join("bad\x1b]2;owned\x07"), "").expect("write temp file");
+    fs::write(base.join("bad\x1b]2;owned\x07\nrow\rcol\tend"), "").expect("write temp file");
 
     let output = Command::new(env!("CARGO_BIN_EXE_wagon"))
         .args(["--color", "--base"])
@@ -39,6 +39,7 @@ fn color_output_sanitizes_repo_paths() {
     assert!(output.status.success(), "command failed: {output:?}");
     let output = [output.stdout, output.stderr].concat();
     assert!(contains(&output, b"\x1b["));
-    assert!(contains(&output, br"bad\x1b]2;owned\x07"));
+    assert!(contains(&output, br"bad\x1b]2;owned\x07\nrow\rcol\tend"));
     assert!(!contains(&output, b"\x1b]2;owned"));
+    assert!(!contains(&output, b"\rcol\tend"));
 }

--- a/tests/color.rs
+++ b/tests/color.rs
@@ -1,0 +1,18 @@
+use std::process::Command;
+
+fn contains(bytes: &[u8], needle: &[u8]) -> bool {
+    bytes.windows(needle.len()).any(|window| window == needle)
+}
+
+#[test]
+fn color_output_keeps_escape_sequences() {
+    let output = Command::new(env!("CARGO_BIN_EXE_wagon"))
+        .args(["--color", "ls", "test/repo/bash"])
+        .output()
+        .expect("run wagon");
+
+    assert!(output.status.success(), "command failed: {output:?}");
+    let output = [output.stdout, output.stderr].concat();
+    assert!(contains(&output, b"\x1b[1mba"));
+    assert!(!contains(&output, br"\x1b"));
+}

--- a/tests/color.rs
+++ b/tests/color.rs
@@ -14,7 +14,7 @@ fn color_output_keeps_escape_sequences() {
 
     assert!(output.status.success(), "command failed: {output:?}");
     let output = [output.stdout, output.stderr].concat();
-    assert!(contains(&output, b"\x1b[1mba"));
+    assert!(contains(&output, b"\x1b["));
     assert!(!contains(&output, br"\x1b"));
 }
 

--- a/tests/color.rs
+++ b/tests/color.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::path::PathBuf;
 use std::process::Command;
 
 fn contains(bytes: &[u8], needle: &[u8]) -> bool {
@@ -7,8 +8,10 @@ fn contains(bytes: &[u8], needle: &[u8]) -> bool {
 
 #[test]
 fn color_output_keeps_escape_sequences() {
+    let base = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test/repo/bash");
     let output = Command::new(env!("CARGO_BIN_EXE_wagon"))
-        .args(["--color", "ls", "test/repo/bash"])
+        .args(["--color", "ls"])
+        .arg(base)
         .output()
         .expect("run wagon");
 


### PR DESCRIPTION
## Summary
- Keep `tracing-subscriber` ANSI sanitization enabled globally.
- Route `wagon ls` terminal output through sanitized CLI output so fixed labels can keep trusted ANSI styling without passing repo-derived control sequences through unchanged.
- Centralize sanitized path display for `Link` so other user-facing `{link}` output is protected consistently.
- Add regression coverage for real ESC bytes, sanitized control characters in paths, and manifest-relative test fixtures.

## Testing
- `cargo fmt --all`
- `cargo test --test color`
- `RUST_TEST_THREADS=1 cargo test`