### PR TITLE
Handle broken symlink failover

### DIFF
--- a/src/link.rs
+++ b/src/link.rs
@@ -5,9 +5,18 @@ use anyhow::Result;
 use colored::Colorize;
 use glob::glob;
 use std::fs;
+use std::io;
 use std::os::unix;
 use std::path::{Path, PathBuf};
 use tracing::{error, info};
+
+fn target_is_missing(path: &Path) -> Result<bool> {
+    match fs::metadata(path) {
+        Ok(_) => Ok(false),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(true),
+        Err(err) => Err(err.into()),
+    }
+}
 
 fn link(base: &Path, backupdir: &Path) -> Result<()> {
     for link in list_items(base, false)? {
@@ -17,7 +26,7 @@ fn link(base: &Path, backupdir: &Path) -> Result<()> {
                 info!("{} {link} (exists)", "SKIPPED:".cyan());
                 continue;
             } else {
-                if !link.target.exists() {
+                if target_is_missing(&link.target)? {
                     error!(
                         "{} broken symlink: {} -> {}",
                         "ERROR:".red(),

--- a/src/link.rs
+++ b/src/link.rs
@@ -1,12 +1,13 @@
 use crate::backup::{backup, get_backuppath};
 use crate::list::list_items;
+use crate::structs::display_path;
 use anyhow::Result;
 use colored::Colorize;
 use glob::glob;
 use std::fs;
 use std::os::unix;
 use std::path::{Path, PathBuf};
-use tracing::info;
+use tracing::{error, info};
 
 fn link(base: &Path, backupdir: &Path) -> Result<()> {
     for link in list_items(base, false)? {
@@ -16,6 +17,14 @@ fn link(base: &Path, backupdir: &Path) -> Result<()> {
                 info!("{} {link} (exists)", "SKIPPED:".cyan());
                 continue;
             } else {
+                if !link.target.exists() {
+                    error!(
+                        "{} broken symlink: {} -> {}",
+                        "ERROR:".red(),
+                        display_path(&link.target),
+                        display_path(&readlink)
+                    );
+                }
                 info!("{} {:?}", "LINK BACKUP:".yellow(), &link.target);
                 backup(backupdir, &link.target)?;
             }

--- a/src/list.rs
+++ b/src/list.rs
@@ -1,9 +1,13 @@
-use crate::{CONFFILE_NAME, IGNOREFILE_NAME, Link, config::get_config, dest::get_dest};
+use crate::{
+    CONFFILE_NAME, IGNOREFILE_NAME, Link, config::get_config, dest::get_dest, structs::display_path,
+};
 use anyhow::Result;
+use colored::Colorize;
 use ignore::{DirEntry, WalkBuilder};
 use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
+use tracing::error;
 
 fn list_diritems(base: &Path) -> Result<HashSet<PathBuf>> {
     let mut items = HashSet::new();
@@ -37,6 +41,27 @@ fn filter_ignores(e: &DirEntry) -> bool {
         || p == ".gitmodules")
 }
 
+fn metadata_or_report_broken_link(path: &Path) -> Result<Option<fs::Metadata>> {
+    match fs::metadata(path) {
+        Ok(meta) => Ok(Some(meta)),
+        Err(err) => match fs::symlink_metadata(path) {
+            Ok(meta) if meta.file_type().is_symlink() => {
+                let target = fs::read_link(path)
+                    .map(|target| format!(" -> {}", display_path(&target)))
+                    .unwrap_or_default();
+                error!(
+                    "{} broken symlink: {}{} ({err})",
+                    "ERROR:".red(),
+                    display_path(path),
+                    target
+                );
+                Ok(None)
+            }
+            _ => Err(err.into()),
+        },
+    }
+}
+
 fn list_dir(base: &Path, dir: &Path, dir_items: &HashSet<PathBuf>) -> Result<Vec<Link>> {
     let mut items = vec![];
     let pat = dir.to_str().unwrap_or_default().to_string();
@@ -50,16 +75,19 @@ fn list_dir(base: &Path, dir: &Path, dir_items: &HashSet<PathBuf>) -> Result<Vec
         match r {
             Ok(dent) => {
                 let p = PathBuf::from(dent.path());
+                let Some(meta) = metadata_or_report_broken_link(&p)? else {
+                    continue;
+                };
                 let f = p.strip_prefix(base).unwrap_or(&p);
                 let dst = get_dest(&p)?.canonicalize()?.join(f);
-                if fs::metadata(&p)?.is_file() {
+                if meta.is_file() {
                     for dir_item in dir_items {
                         if p.starts_with(dir_item) {
                             continue 'walk;
                         }
                     }
                     items.push(Link::new(p.canonicalize()?, dst, false));
-                } else if fs::metadata(&p)?.is_dir() && dir_items.contains(&p) {
+                } else if meta.is_dir() && dir_items.contains(&p) {
                     items.push(Link::new(p.canonicalize()?, dst, true));
                 }
             }

--- a/src/list.rs
+++ b/src/list.rs
@@ -6,6 +6,7 @@ use colored::Colorize;
 use ignore::{DirEntry, WalkBuilder};
 use std::collections::HashSet;
 use std::fs;
+use std::io;
 use std::path::{Path, PathBuf};
 use tracing::error;
 
@@ -44,21 +45,26 @@ fn filter_ignores(e: &DirEntry) -> bool {
 fn metadata_or_report_broken_link(path: &Path) -> Result<Option<fs::Metadata>> {
     match fs::metadata(path) {
         Ok(meta) => Ok(Some(meta)),
-        Err(err) => match fs::symlink_metadata(path) {
-            Ok(meta) if meta.file_type().is_symlink() => {
-                let target = fs::read_link(path)
-                    .map(|target| format!(" -> {}", display_path(&target)))
-                    .unwrap_or_default();
-                error!(
-                    "{} broken symlink: {}{} ({err})",
-                    "ERROR:".red(),
-                    display_path(path),
-                    target
-                );
-                Ok(None)
+        Err(err) => {
+            if err.kind() != io::ErrorKind::NotFound {
+                return Err(err.into());
             }
-            _ => Err(err.into()),
-        },
+            match fs::symlink_metadata(path) {
+                Ok(meta) if meta.file_type().is_symlink() => {
+                    let target = fs::read_link(path)
+                        .map(|target| format!(" -> {}", display_path(&target)))
+                        .unwrap_or_default();
+                    error!(
+                        "{} broken symlink: {}{} ({err})",
+                        "ERROR:".red(),
+                        display_path(path),
+                        target
+                    );
+                    Ok(None)
+                }
+                _ => Err(err.into()),
+            }
+        }
     }
 }
 

--- a/src/show.rs
+++ b/src/show.rs
@@ -76,7 +76,7 @@ fn show_existing_target(link: &Link) -> Result<Vec<String>> {
         "EXISTS".magenta(),
         display_path(&link.target)
     )];
-    if !link.is_dir {
+    if !link.is_dir && fs::metadata(&link.target)?.is_file() {
         lines.push(show_content_diff(link)?)
     }
     Ok(lines)

--- a/src/show.rs
+++ b/src/show.rs
@@ -6,7 +6,7 @@ use crate::{
 use anyhow::Result;
 use colored::Colorize;
 use std::fs;
-use std::io::Read;
+use std::io::{self, Read};
 use std::path::{Path, PathBuf};
 
 fn read_text(f: &mut fs::File) -> Result<Content> {
@@ -70,13 +70,21 @@ fn show_content_diff(link: &Link) -> Result<String> {
     })
 }
 
-fn show_existing_target(link: &Link) -> Result<Vec<String>> {
+fn target_metadata(path: &Path) -> Result<Option<fs::Metadata>> {
+    match fs::metadata(path) {
+        Ok(meta) => Ok(Some(meta)),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(err) => Err(err.into()),
+    }
+}
+
+fn show_existing_target(link: &Link, target_meta: &fs::Metadata) -> Result<Vec<String>> {
     let mut lines = vec![format!(
         "{}: {}",
         "EXISTS".magenta(),
         display_path(&link.target)
     )];
-    if !link.is_dir && fs::metadata(&link.target)?.is_file() {
+    if !link.is_dir && target_meta.is_file() {
         lines.push(show_content_diff(link)?)
     }
     Ok(lines)
@@ -85,11 +93,22 @@ fn show_existing_target(link: &Link) -> Result<Vec<String>> {
 fn show_link(base: &Path) -> Result<String> {
     let mut vs = vec![];
     for link in list_items(base, false)? {
+        let target_meta = match target_metadata(&link.target) {
+            Ok(meta) => meta,
+            Err(err) => {
+                vs.push(format!(
+                    "{} cannot access: {} ({err})",
+                    "ERROR:".red(),
+                    display_path(&link.target)
+                ));
+                continue;
+            }
+        };
         if let Ok(readlink) = fs::read_link(&link.target) {
             if readlink == link.source {
                 vs.push(format!("{}: {}", "LINKING".cyan(), &link))
-            } else if link.target.exists() {
-                vs.extend(show_existing_target(&link)?)
+            } else if let Some(meta) = target_meta.as_ref() {
+                vs.extend(show_existing_target(&link, meta)?)
             } else {
                 vs.push(format!(
                     "{} broken symlink: {} -> {}",
@@ -99,8 +118,8 @@ fn show_link(base: &Path) -> Result<String> {
                 ));
                 vs.push(format!("{}: {}", "NOLINK".yellow(), &link))
             }
-        } else if link.target.exists() {
-            vs.extend(show_existing_target(&link)?)
+        } else if let Some(meta) = target_meta.as_ref() {
+            vs.extend(show_existing_target(&link, meta)?)
         } else {
             vs.push(format!("{}: {}", "NOLINK".yellow(), &link))
         }

--- a/src/show.rs
+++ b/src/show.rs
@@ -70,24 +70,37 @@ fn show_content_diff(link: &Link) -> Result<String> {
     })
 }
 
+fn show_existing_target(link: &Link) -> Result<Vec<String>> {
+    let mut lines = vec![format!(
+        "{}: {}",
+        "EXISTS".magenta(),
+        display_path(&link.target)
+    )];
+    if !link.is_dir {
+        lines.push(show_content_diff(link)?)
+    }
+    Ok(lines)
+}
+
 fn show_link(base: &Path) -> Result<String> {
     let mut vs = vec![];
     for link in list_items(base, false)? {
-        if link.target.exists() {
-            if let Ok(readlink) = fs::read_link(&link.target) {
-                if readlink == link.source {
-                    vs.push(format!("{}: {}", "LINKING".cyan(), &link))
-                }
+        if let Ok(readlink) = fs::read_link(&link.target) {
+            if readlink == link.source {
+                vs.push(format!("{}: {}", "LINKING".cyan(), &link))
+            } else if link.target.exists() {
+                vs.extend(show_existing_target(&link)?)
             } else {
                 vs.push(format!(
-                    "{}: {}",
-                    "EXISTS".magenta(),
-                    display_path(&link.target)
+                    "{} broken symlink: {} -> {}",
+                    "ERROR:".red(),
+                    display_path(&link.target),
+                    display_path(&readlink)
                 ));
-                if !link.is_dir {
-                    vs.push(show_content_diff(&link)?)
-                }
+                vs.push(format!("{}: {}", "NOLINK".yellow(), &link))
             }
+        } else if link.target.exists() {
+            vs.extend(show_existing_target(&link)?)
         } else {
             vs.push(format!("{}: {}", "NOLINK".yellow(), &link))
         }

--- a/tests/symlink.rs
+++ b/tests/symlink.rs
@@ -1,0 +1,88 @@
+use std::fs;
+use std::os::unix::fs::symlink;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn temp_dir(name: &str) -> PathBuf {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time")
+        .as_nanos();
+    std::env::temp_dir().join(format!("wagon-{name}-{}-{now}", std::process::id()))
+}
+
+fn write_repo(base: &Path, dest: &Path) {
+    fs::create_dir_all(base).expect("create repo");
+    fs::create_dir_all(dest).expect("create dest");
+    fs::write(base.join(".wagon.toml"), format!("dest = {:?}\n", dest)).expect("write config");
+    fs::write(base.join(".bashrc"), "new\n").expect("write source");
+}
+
+fn output_text(output: &std::process::Output) -> String {
+    String::from_utf8_lossy(&[output.stdout.as_slice(), output.stderr.as_slice()].concat())
+        .into_owned()
+}
+
+#[test]
+fn link_reports_and_replaces_broken_target_symlink() {
+    let root = temp_dir("broken-target");
+    let base = root.join("repo");
+    let dest = root.join("home");
+    write_repo(&base, &dest);
+    symlink(root.join("missing"), dest.join(".bashrc")).expect("create broken symlink");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_wagon"))
+        .current_dir(&root)
+        .args(["--base"])
+        .arg(&base)
+        .arg("link")
+        .output()
+        .expect("run wagon");
+
+    assert!(output.status.success(), "command failed: {output:?}");
+    assert_eq!(
+        fs::read_link(dest.join(".bashrc")).expect("read replaced symlink"),
+        base.join(".bashrc")
+            .canonicalize()
+            .expect("canonical source")
+    );
+    assert!(
+        output_text(&output).contains("ERROR: broken symlink:"),
+        "output: {output:?}"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn link_reports_broken_source_symlink_and_continues() {
+    let root = temp_dir("broken-source");
+    let base = root.join("repo");
+    let dest = root.join("home");
+    write_repo(&base, &dest);
+    symlink(root.join("missing"), base.join("broken")).expect("create broken symlink");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_wagon"))
+        .current_dir(&root)
+        .args(["--base"])
+        .arg(&base)
+        .arg("link")
+        .output()
+        .expect("run wagon");
+
+    assert!(output.status.success(), "command failed: {output:?}");
+    assert_eq!(
+        fs::read_link(dest.join(".bashrc")).expect("read linked file"),
+        base.join(".bashrc")
+            .canonicalize()
+            .expect("canonical source")
+    );
+    assert!(fs::symlink_metadata(dest.join("broken")).is_err());
+    assert!(
+        output_text(&output).contains("ERROR: broken symlink:"),
+        "output: {output:?}"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}

--- a/tests/symlink.rs
+++ b/tests/symlink.rs
@@ -86,3 +86,30 @@ fn link_reports_broken_source_symlink_and_continues() {
 
     let _ = fs::remove_dir_all(root);
 }
+
+#[test]
+fn list_reports_directory_symlink_conflict_without_diffing() {
+    let root = temp_dir("directory-target");
+    let base = root.join("repo");
+    let dest = root.join("home");
+    let existing_dir = root.join("existing-dir");
+    write_repo(&base, &dest);
+    fs::create_dir_all(&existing_dir).expect("create existing dir");
+    symlink(&existing_dir, dest.join(".bashrc")).expect("create directory symlink");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_wagon"))
+        .current_dir(&root)
+        .args(["--base"])
+        .arg(&base)
+        .arg("ls")
+        .output()
+        .expect("run wagon");
+
+    assert!(output.status.success(), "command failed: {output:?}");
+    assert!(
+        output_text(&output).contains("EXISTS"),
+        "output: {output:?}"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}


### PR DESCRIPTION
## Summary

- Report broken symlinks found while scanning the source tree and keep processing other managed items.
- Report broken destination symlinks before replacing them during `wagon link`.
- Show broken destination symlinks in `wagon ls` as an error plus `NOLINK`.
- Add CLI regression coverage for source-side skip and destination-side relink behavior.

## Why

`Path::exists()` and `fs::metadata()` treat dangling symlinks as missing, so broken links could be silently classified as absent or stop traversal without a clear recovery path.

## Impact

Users now get an explicit `ERROR: broken symlink:` message while wagon continues with remaining items. Destination links can be backed up and recreated instead of blocking the run.

## Validation

- `cargo test`

Note: the existing `time::format_description::parse` deprecated warning still appears and is unrelated to this change.