### PR TITLE
Redirect command output to stderr and preserve colored escapes

### DIFF
--- a/src/copy.rs
+++ b/src/copy.rs
@@ -1,5 +1,6 @@
 use crate::backup::{backup, get_backuppath};
 use crate::list::list_items;
+use crate::structs::display_path;
 use anyhow::Result;
 use colored::Colorize;
 use std::fs;
@@ -16,7 +17,7 @@ fn copy(base: &Path, backupdir: &Path) -> Result<()> {
                 eprintln!("{} {link} (exists)", "SKIP:".cyan());
                 continue;
             }
-            eprintln!("{} {:?}", "BACKUP:".yellow(), &link.target);
+            eprintln!("{} {}", "BACKUP:".yellow(), display_path(&link.target));
             backup(backupdir, &link.target)?;
         }
         eprintln!("{} {}", "COPY:".green(), &link);

--- a/src/copy.rs
+++ b/src/copy.rs
@@ -4,7 +4,6 @@ use anyhow::Result;
 use colored::Colorize;
 use std::fs;
 use std::path::{Path, PathBuf};
-use tracing::info;
 
 fn copy(base: &Path, backupdir: &Path) -> Result<()> {
     for link in list_items(base, true)? {
@@ -14,13 +13,13 @@ fn copy(base: &Path, backupdir: &Path) -> Result<()> {
             if let Ok(content) = fs::read(&link.target)
                 && content == content_src
             {
-                info!("{} {link} (exists)", "SKIP:".cyan());
+                eprintln!("{} {link} (exists)", "SKIP:".cyan());
                 continue;
             }
-            info!("{} {:?}", "BACKUP:".yellow(), &link.target);
+            eprintln!("{} {:?}", "BACKUP:".yellow(), &link.target);
             backup(backupdir, &link.target)?;
         }
-        info!("{} {}", "COPY:".green(), &link);
+        eprintln!("{} {}", "COPY:".green(), &link);
         fs::copy(link.source, link.target)?;
     }
     Ok(())

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,9 +1,11 @@
-use crate::config::get_config;
+use crate::{
+    config::get_config,
+    structs::{sanitize_display, sanitize_output},
+};
 use anyhow::Result;
 use colored::Colorize;
 use std::env::consts;
 use std::path::{Path, PathBuf};
-use tracing::info;
 
 fn run_init(base: &Path) -> Result<()> {
     if let Some(conf) = get_config(base)? {
@@ -13,18 +15,18 @@ fn run_init(base: &Path) -> Result<()> {
             {
                 continue;
             }
-            info!(
+            eprintln!(
                 "{}: {} {}",
                 "COMMAND".cyan(),
-                initc.command,
-                initc.args.join(" ")
+                sanitize_display(&initc.command),
+                sanitize_display(&initc.args.join(" "))
             );
             match std::process::Command::new(initc.command)
                 .args(initc.args)
                 .output()
             {
-                Ok(out) => info!("{}", String::from_utf8(out.stdout)?),
-                Err(e) => info!("Error: {e:?}"),
+                Ok(out) => eprintln!("{}", sanitize_output(&String::from_utf8(out.stdout)?)),
+                Err(e) => eprintln!("Error: {e:?}"),
             }
         }
     }

--- a/src/link.rs
+++ b/src/link.rs
@@ -8,7 +8,6 @@ use std::fs;
 use std::io;
 use std::os::unix;
 use std::path::{Path, PathBuf};
-use tracing::{error, info};
 
 fn target_is_missing(path: &Path) -> Result<bool> {
     match fs::metadata(path) {
@@ -23,26 +22,26 @@ fn link(base: &Path, backupdir: &Path) -> Result<()> {
         fs::create_dir_all(link.target.parent().unwrap_or_else(|| Path::new("/")))?;
         if let Ok(readlink) = fs::read_link(&link.target) {
             if readlink == link.source {
-                info!("{} {link} (exists)", "SKIPPED:".cyan());
+                eprintln!("{} {link} (exists)", "SKIPPED:".cyan());
                 continue;
             } else {
                 if target_is_missing(&link.target)? {
-                    error!(
+                    eprintln!(
                         "{} broken symlink: {} -> {}",
                         "ERROR:".red(),
                         display_path(&link.target),
                         display_path(&readlink)
                     );
                 }
-                info!("{} {:?}", "LINK BACKUP:".yellow(), &link.target);
+                eprintln!("{} {:?}", "LINK BACKUP:".yellow(), &link.target);
                 backup(backupdir, &link.target)?;
             }
         } else if link.target.exists() {
-            info!("{} {:?}", "BACKUP:".yellow(), &link.target);
+            eprintln!("{} {:?}", "BACKUP:".yellow(), &link.target);
             backup(backupdir, &link.target)?;
         }
         unix::fs::symlink(&link.source, &link.target)?;
-        info!("{} {}", "LINKED:".green(), &link);
+        eprintln!("{} {}", "LINKED:".green(), &link);
     }
     Ok(())
 }
@@ -65,7 +64,7 @@ fn unlink(base: &Path) -> Result<()> {
             && let Ok(readlink) = fs::read_link(&link.target)
             && readlink == link.source
         {
-            info!("{} {link} (exists)", "UNLINK:".cyan());
+            eprintln!("{} {link} (exists)", "UNLINK:".cyan());
             fs::remove_file(&link.target)?;
             cleanup_dir(link.target.parent())?;
         }

--- a/src/link.rs
+++ b/src/link.rs
@@ -33,11 +33,11 @@ fn link(base: &Path, backupdir: &Path) -> Result<()> {
                         display_path(&readlink)
                     );
                 }
-                eprintln!("{} {:?}", "LINK BACKUP:".yellow(), &link.target);
+                eprintln!("{} {}", "LINK BACKUP:".yellow(), display_path(&link.target));
                 backup(backupdir, &link.target)?;
             }
         } else if link.target.exists() {
-            eprintln!("{} {:?}", "BACKUP:".yellow(), &link.target);
+            eprintln!("{} {}", "BACKUP:".yellow(), display_path(&link.target));
             backup(backupdir, &link.target)?;
         }
         unix::fs::symlink(&link.source, &link.target)?;

--- a/src/list.rs
+++ b/src/list.rs
@@ -8,7 +8,6 @@ use std::collections::HashSet;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
-use tracing::error;
 
 fn list_diritems(base: &Path) -> Result<HashSet<PathBuf>> {
     let mut items = HashSet::new();
@@ -54,7 +53,7 @@ fn metadata_or_report_broken_link(path: &Path) -> Result<Option<fs::Metadata>> {
                     let target = fs::read_link(path)
                         .map(|target| format!(" -> {}", display_path(&target)))
                         .unwrap_or_default();
-                    error!(
+                    eprintln!(
                         "{} broken symlink: {}{} ({err})",
                         "ERROR:".red(),
                         display_path(path),

--- a/src/pull.rs
+++ b/src/pull.rs
@@ -1,9 +1,8 @@
-use crate::config::get_config;
+use crate::{config::get_config, structs::display_path};
 use anyhow::Result;
 use colored::Colorize;
 use std::fs;
 use std::path::{Path, PathBuf};
-use tracing::info;
 
 pub fn absolute_path(value: &str) -> std::result::Result<PathBuf, String> {
     let path = PathBuf::from(value);
@@ -20,19 +19,19 @@ pub fn pull_files(base: &Path, dir: &Path, targets: &[PathBuf]) -> Result<()> {
         for target in targets {
             if target.is_file() {
                 let to = dir.join(target.strip_prefix(&dest)?);
-                info!(
+                eprintln!(
                     "{}: {} -> {}",
                     "PULL".cyan(),
-                    target.to_str().unwrap_or_default(),
-                    to.to_str().unwrap_or_default(),
+                    display_path(target),
+                    display_path(&to),
                 );
                 fs::create_dir_all(to.parent().unwrap_or(dir))?;
                 fs::copy(target, to)?;
             } else {
-                info!(
+                eprintln!(
                     "{}: {} is directory",
                     "SKIPPED".yellow(),
-                    target.to_str().unwrap_or_default()
+                    display_path(target)
                 );
             }
         }

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -87,4 +87,12 @@ mod tests {
             "dst\\nbad\\rname -> src\\x1b]2;owned\\x07\\tname"
         );
     }
+
+    #[test]
+    fn output_sanitization_preserves_lines() {
+        assert_eq!(
+            sanitize_output("first\nsecond\x1b]2;owned\x07"),
+            "first\nsecond\\x1b]2;owned\\x07"
+        );
+    }
 }

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -1,18 +1,14 @@
 use std::path::{Path, PathBuf};
 
-pub(crate) fn sanitize_display(text: &str) -> String {
+pub(crate) fn sanitize_output(text: &str) -> String {
     let mut out = String::with_capacity(text.len());
     for ch in text.chars() {
         match ch {
-            '\n' => out.push_str("\\n"),
-            '\r' => out.push_str("\\r"),
-            '\t' => out.push_str("\\t"),
             '\x1b' => out.push_str("\\x1b"),
             '\x07' => out.push_str("\\x07"),
             '\x08' => out.push_str("\\x08"),
             '\x0c' => out.push_str("\\x0c"),
             '\x7f' => out.push_str("\\x7f"),
-            ch if ch < ' ' => out.push_str(&format!("\\x{:02x}", ch as u32)),
             ch if ('\u{80}'..='\u{9f}').contains(&ch) => {
                 out.push_str(&format!("\\u{{{:x}}}", ch as u32));
             }
@@ -20,6 +16,21 @@ pub(crate) fn sanitize_display(text: &str) -> String {
         }
     }
     out
+}
+
+pub(crate) fn sanitize_display(text: &str) -> String {
+    sanitize_output(text)
+        .chars()
+        .fold(String::new(), |mut out, ch| {
+            match ch {
+                '\n' => out.push_str("\\n"),
+                '\r' => out.push_str("\\r"),
+                '\t' => out.push_str("\\t"),
+                ch if ch < ' ' => out.push_str(&format!("\\x{:02x}", ch as u32)),
+                _ => out.push(ch),
+            }
+            out
+        })
 }
 
 pub(crate) fn display_path(path: &Path) -> String {

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -4,11 +4,15 @@ pub(crate) fn sanitize_output(text: &str) -> String {
     let mut out = String::with_capacity(text.len());
     for ch in text.chars() {
         match ch {
+            '\n' => out.push(ch),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
             '\x1b' => out.push_str("\\x1b"),
             '\x07' => out.push_str("\\x07"),
             '\x08' => out.push_str("\\x08"),
             '\x0c' => out.push_str("\\x0c"),
             '\x7f' => out.push_str("\\x7f"),
+            ch if ch < ' ' => out.push_str(&format!("\\x{:02x}", ch as u32)),
             ch if ('\u{80}'..='\u{9f}').contains(&ch) => {
                 out.push_str(&format!("\\u{{{:x}}}", ch as u32));
             }
@@ -19,18 +23,7 @@ pub(crate) fn sanitize_output(text: &str) -> String {
 }
 
 pub(crate) fn sanitize_display(text: &str) -> String {
-    sanitize_output(text)
-        .chars()
-        .fold(String::default(), |mut out, ch| {
-            match ch {
-                '\n' => out.push_str("\\n"),
-                '\r' => out.push_str("\\r"),
-                '\t' => out.push_str("\\t"),
-                ch if ch < ' ' => out.push_str(&format!("\\x{:02x}", ch as u32)),
-                _ => out.push(ch),
-            }
-            out
-        })
+    sanitize_output(text).replace('\n', "\\n")
 }
 
 pub(crate) fn display_path(path: &Path) -> String {

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -82,10 +82,10 @@ mod tests {
     }
 
     #[test]
-    fn output_sanitization_preserves_lines() {
+    fn output_sanitization_preserves_only_newlines() {
         assert_eq!(
-            sanitize_output("first\nsecond\x1b]2;owned\x07"),
-            "first\nsecond\\x1b]2;owned\\x07"
+            sanitize_output("first\nsecond\rrewrite\tcolumn\0end\x1b]2;owned\x07"),
+            "first\nsecond\\rrewrite\\tcolumn\\x00end\\x1b]2;owned\\x07"
         );
     }
 }

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -21,7 +21,7 @@ pub(crate) fn sanitize_output(text: &str) -> String {
 pub(crate) fn sanitize_display(text: &str) -> String {
     sanitize_output(text)
         .chars()
-        .fold(String::new(), |mut out, ch| {
+        .fold(String::default(), |mut out, ch| {
             match ch {
                 '\n' => out.push_str("\\n"),
                 '\r' => out.push_str("\\r"),

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,8 +1,7 @@
-use crate::config::get_config;
+use crate::{config::get_config, structs::sanitize_output};
 use anyhow::Result;
 use std::env::consts;
 use std::path::{Path, PathBuf};
-use tracing::info;
 
 fn run_update(base: &Path) -> Result<()> {
     if let Some(conf) = get_config(base)? {
@@ -16,8 +15,8 @@ fn run_update(base: &Path) -> Result<()> {
                 .args(updatec.args)
                 .output()
             {
-                Ok(out) => info!("{}", String::from_utf8(out.stdout)?),
-                Err(e) => info!("Error: {:?}", e),
+                Ok(out) => eprintln!("{}", sanitize_output(&String::from_utf8(out.stdout)?)),
+                Err(e) => eprintln!("Error: {e:?}"),
             }
         }
     }

--- a/tests/color.rs
+++ b/tests/color.rs
@@ -22,6 +22,35 @@ fn color_output_keeps_escape_sequences() {
 }
 
 #[test]
+fn link_and_copy_outputs_keep_escape_sequences() {
+    let root =
+        std::env::temp_dir().join(format!("wagon-command-color-test-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&root);
+
+    for command in ["link", "copy"] {
+        let base = root.join(command).join("repo");
+        let dest = root.join(command).join("home");
+        fs::create_dir_all(&base).expect("create temp repo");
+        fs::create_dir_all(&dest).expect("create temp destination");
+        fs::write(base.join(".wagon.toml"), format!("dest = {dest:?}\n")).expect("write config");
+        fs::write(base.join("file"), "content").expect("write source file");
+
+        let output = Command::new(env!("CARGO_BIN_EXE_wagon"))
+            .args(["--color", "--base"])
+            .arg(&base)
+            .arg(command)
+            .output()
+            .expect("run wagon");
+
+        assert!(output.status.success(), "command failed: {output:?}");
+        assert!(contains(&output.stderr, b"\x1b["), "output: {output:?}");
+        assert!(!contains(&output.stderr, br"\x1b"), "output: {output:?}");
+    }
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
 fn color_output_sanitizes_repo_paths() {
     let base = std::env::temp_dir().join(format!("wagon-color-test-{}", std::process::id()));
     let _ = fs::remove_dir_all(&base);


### PR DESCRIPTION
## Summary
- Send user-facing command logs to `stderr` instead of tracing output in `copy`, `link`, `pull`, `init`, and `update`
- Add output sanitization so command stdout is printed without hiding normal newlines
- Keep path and command display safe by escaping control characters while preserving readable output
- Extend tests to cover escape-sequence handling for `link` and `copy`

## Testing
- Added unit coverage for output sanitization behavior
- Added integration coverage for colored `link` and `copy` output preserving escape sequences
- Not run (not requested)