### PR TITLE
fix: use explicit time format parser

### DIFF
--- a/src/backup.rs
+++ b/src/backup.rs
@@ -30,9 +30,23 @@ pub fn get_backuppath() -> Result<PathBuf> {
     let mut backupdir = PathBuf::from(".backups");
     backupdir.push(format!("uid{}", unsafe { getuid() }));
     let local = time::OffsetDateTime::now_local()?;
+    backupdir.push(format_backuptime(local)?);
+    Ok(backupdir)
+}
+
+fn format_backuptime(datetime: time::OffsetDateTime) -> Result<String> {
     let format = time::format_description::parse_borrowed::<2>(
         "[year]/[month]/[day]/[hour]:[minute]:[second]",
     )?;
-    backupdir.push(local.format(&format)?);
-    Ok(backupdir)
+    Ok(datetime.format(&format)?)
+}
+
+#[test]
+fn formats_backup_time() -> Result<()> {
+    let datetime = time::Date::from_calendar_date(2026, time::Month::July, 19)?
+        .with_hms(12, 34, 56)?
+        .assume_utc();
+
+    assert_eq!(format_backuptime(datetime)?, "2026/07/19/12:34:56");
+    Ok(())
 }

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -30,7 +30,9 @@ pub fn get_backuppath() -> Result<PathBuf> {
     let mut backupdir = PathBuf::from(".backups");
     backupdir.push(format!("uid{}", unsafe { getuid() }));
     let local = time::OffsetDateTime::now_local()?;
-    let format = time::format_description::parse("[year]/[month]/[day]/[hour]:[minute]:[second]")?;
+    let format = time::format_description::parse_borrowed::<2>(
+        "[year]/[month]/[day]/[hour]:[minute]:[second]",
+    )?;
     backupdir.push(local.format(&format)?);
     Ok(backupdir)
 }


### PR DESCRIPTION
## Summary

- replace the deprecated `time::format_description::parse` API
- use the recommended borrowed parser with format description version 2

## Why

`cargo clippy --all-targets -- -D warnings` failed because the previous parser API is deprecated in the current `time` release.

## Impact

Backup path formatting remains unchanged while the project builds cleanly with warnings denied.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `RUST_TEST_THREADS=1 cargo test` (24 passed)
